### PR TITLE
Fix the misunderstanding of the restock procedure

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -147,11 +147,11 @@ def restock_product(iid):
     need = ans.restock_level
     added = 0
     if cur < need:
-        added = need - cur + ans.restock_count
+        added = need - cur
     else:
         added = ans.restock_count
     ans.quantity += added
-    #ans.restock_count = added
+    # ans.restock_count = added
     ans.last_restock_date = datetime.today()
     app.logger.info("Restock %d units of product %d", added, need)
     ans.update()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -353,7 +353,7 @@ class TestYourResourceServer(TestCase):
         response = self.client.get(f"{BASE_URL}/{id_1}")
         data = response.get_json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(data["quantity"], 120)
+        self.assertEqual(data["quantity"], 100)
         self.assertEqual(
             data["last_restock_date"], datetime.today().strftime("%Y-%m-%d")
         )


### PR DESCRIPTION
Misunderstanding of the restock procedure. Now the procedure is:
1. If the quantity is below the restock_level, increase the quantity to restock_level;
2. if the quantity is above the restock_level, increase the quantity by restock_count;